### PR TITLE
fix(release): trigger v0.1.2 (v0.1.1 tag has broken release.yaml)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,10 @@ jobs:
         run: |
           make installer
           # GoReleaser refuses to release with a dirty tree. The install
-          # manifest is regenerated at release time and not tracked; stage
-          # it into a throw-away CI-local commit so GoReleaser sees a clean
-          # tree. The bytes stay on disk for upload as a release asset.
+          # manifest (dist/install.yaml) is regenerated at release time
+          # and not tracked, so stage it into a throw-away CI-local
+          # commit before GoReleaser runs. The bytes stay on disk for
+          # upload as a release asset.
           git add -A
           git -c user.email=ci@local -c user.name=ci commit -m "ci: release artifacts" --allow-empty
 


### PR DESCRIPTION
## Summary

The v0.1.1 tag was cut from a commit whose release.yaml had GoReleaser
running against a dirty tree (`make installer` creates `dist/install.yaml`
in the workspace, which goreleaser sees and refuses to release).

The fix landed in a later `chore()` commit but release-please's chore-type commits don't trigger a new release per the project's release-please-config. This `fix()` bump asks release-please to cut v0.1.2 so the tag finally points at a release.yaml that works.

The diff itself is just a clarifying comment in the dirty-tree workaround step — the load-bearing edit is the conventional-commit type.

## Test plan

- [ ] release-please opens a v0.1.2 release PR after this merges
- [ ] After v0.1.2 is tagged, the Release workflow completes end-to-end (GoReleaser → Cosign → Syft → Helm OCI push)