### PR TITLE
fix(ci): drop --remote from gh repo fork in operatorhub-submit

### DIFF
--- a/.github/workflows/operatorhub-submit.yaml
+++ b/.github/workflows/operatorhub-submit.yaml
@@ -63,7 +63,7 @@ jobs:
           BRANCH="hermes-operator-v${VERSION}"
 
           gh auth setup-git
-          gh repo fork k8s-operatorhub/community-operators --clone=true --remote=true -- community-operators
+          gh repo fork k8s-operatorhub/community-operators --clone=true -- community-operators
           cd community-operators
 
           git config user.name "github-actions[bot]"
@@ -151,7 +151,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="hermes-operator-v${VERSION}"
           gh auth setup-git
-          gh repo fork redhat-openshift-ecosystem/community-operators-prod --clone=true --remote=true -- community-operators-prod
+          gh repo fork redhat-openshift-ecosystem/community-operators-prod --clone=true -- community-operators-prod
           cd community-operators-prod
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

Newer \`gh\` CLI rejects \`--remote\` when a repository argument is given:

\`\`\`
the --remote flag is unsupported when a repository argument is provided
\`\`\`

This broke the v0.1.6 OperatorHub auto-submit. \`--clone=true\` with a repo arg already sets up upstream, so \`--remote\` is redundant.

## Test plan

- [ ] Re-run \`operatorhub-submit\` workflow against v0.1.6 after merge; expect PR open in k8s-operatorhub/community-operators and redhat-openshift-ecosystem/community-operators-prod