### PR TITLE
ci: release-please uses paperclip-release-bot App token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,8 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
@@ -16,10 +15,18 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       sha: ${{ steps.release.outputs.sha }}
     steps:
+      # Mint a short-lived token (~1h) from the paperclip-release-bot App.
+      # Avoids long-lived PATs that the paperclipinc org policy blocks.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -32,25 +39,31 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Create and push release tag
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
           SHA: ${{ needs.release-please.outputs.sha }}
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name  "release-please[bot]"
-          git config user.email "release-please[bot]@users.noreply.github.com"
+          git config user.name  "paperclip-release-bot[bot]"
+          git config user.email "paperclip-release-bot[bot]@users.noreply.github.com"
           git tag -a "${TAG}" "${SHA}" -m "Release ${TAG}"
           git push origin "${TAG}"
 
       - name: Flip stale autorelease labels on older open PRs
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           # Remove autorelease:pending / autorelease:tagged from any PRs that


### PR DESCRIPTION
Replaces the long-lived PAT (`secrets.RELEASE_PLEASE_TOKEN`) with a short-lived App installation token minted via `actions/create-github-app-token@v1` from the new `paperclip-release-bot` GitHub App. The org policy now blocks fine-grained PATs >366 days, which is why the most recent release-please run on this repo failed. App tokens are scoped to ~1h and don't have a lifetime cap.

After this merges, the `RELEASE_PLEASE_TOKEN` repo secret can be deleted (no longer referenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)