### PR TITLE
fix(ci): operatorhub-submit uses classic PAT with public_repo scope

### DIFF
--- a/.github/workflows/operatorhub-submit.yaml
+++ b/.github/workflows/operatorhub-submit.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Fork and submit to community-operators
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPERATORHUB_FORK_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
@@ -145,7 +145,7 @@ jobs:
 
       - name: Fork and submit to redhat community-operators-prod
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPERATORHUB_FORK_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Problem

`operatorhub-submit.yaml` forks the external `k8s-operatorhub/community-operators` repo, but the previously-used fine-grained PAT (`secrets.RELEASE_PLEASE_TOKEN`) returned HTTP 403 on fork. Fine-grained PATs cannot fork repos owned by an arbitrary external user/org — they're scoped to specific resource owners and forking requires admin on the source repo.

## Fix

Switch to `secrets.OPERATORHUB_FORK_TOKEN`, a classic PAT with only `public_repo` scope. Classic PATs aren't subject to the org's 366-day fine-grained-PAT lifetime cap, and `public_repo` is the minimum scope needed to fork.

After this merges, manually trigger the workflow (`gh workflow run operatorhub-submit.yaml -f tag=v0.1.8`) to submit hermes for the first time to community-operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)