### PR TITLE
docs: use paperclip.inc maintainer/contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jannes@aqora.io. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jannes@paperclip.inc. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,7 @@ Maintainers may step down at any time by sending a PR to `MAINTAINERS.md`. Maint
 
 ## Code of Conduct
 
-All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Reports go to `jannes@aqora.io`.
+All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Reports go to `jannes@paperclip.inc`.
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting
 
-Use [GitHub's private vulnerability reporting](https://github.com/paperclipinc/hermes-operator/security/advisories/new): this routes a private advisory to the maintainers and is the preferred path. As a fallback, email **jannes@aqora.io** with subject "SECURITY: hermes-operator".
+Use [GitHub's private vulnerability reporting](https://github.com/paperclipinc/hermes-operator/security/advisories/new): this routes a private advisory to the maintainers and is the preferred path. As a fallback, email **jannes@paperclip.inc** with subject "SECURITY: hermes-operator".
 
 We aim to acknowledge within 72 hours and provide a remediation timeline within 7 days.
 

--- a/bundle/manifests/hermes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hermes-operator.clusterserviceversion.yaml
@@ -214,7 +214,7 @@ spec:
     - python
   maintainers:
     - name: Jannes Stubbemann
-      email: jannes@aqora.io
+      email: jannes@paperclip.inc
   provider:
     name: paperclipinc
     url: https://github.com/paperclipinc/hermes-operator

--- a/charts/hermes-operator/Chart.yaml
+++ b/charts/hermes-operator/Chart.yaml
@@ -10,4 +10,4 @@ sources:
   - https://github.com/paperclipinc/hermes-operator
 maintainers:
   - name: paperclipinc
-    email: jannes@aqora.io
+    email: jannes@paperclip.inc


### PR DESCRIPTION
Finish the org migration's last loose end: the project still used the personal `jannes@aqora.io` address as its contact/maintainer email. Switch to `jannes@paperclip.inc` (paperclipinc org; matches the openclaw-operator convention).

Changed:
- `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `SECURITY.md` (fallback contact)
- `charts/hermes-operator/Chart.yaml` → `maintainers[].email`
- `bundle/manifests/hermes-operator.clusterserviceversion.yaml` → `maintainers[].email` (this is what shows on the OperatorHub listing)

The `openclaw.rocks` references elsewhere are intentional (the OpenClaw→Hermes migration feature) and left unchanged. Historical planning docs under `docs/superpowers/` are also left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)