### PR TITLE
fix(agent-image): relock uses uv image entrypoint (unblocks hermes-agent publish)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ agent-image-relock:
 		-v $(PWD)/images/hermes-agent:/work \
 		-w /work \
 		ghcr.io/astral-sh/uv:0.5.0 \
-		sh -c "uv lock"
+		lock
 	@echo "Updated images/hermes-agent/pyproject.toml and uv.lock for hermes-agent@$(HERMES_VERSION)"
 
 # Smoke-test a locally built image: --help should exit 0.


### PR DESCRIPTION
`make agent-image-relock` (and the new CI relock workflow) failed with `error: unrecognized subcommand 'sh'`. The `ghcr.io/astral-sh/uv` image is distroless with `uv` as its entrypoint, so `docker run … uv:0.5.0 sh -c "uv lock"` passes `sh` to `uv` as a subcommand — and there's no shell in the image to fall back to. This is the root reason the lockfile was never generated and `ghcr.io/paperclipinc/hermes-agent` was never published.

Fix: pass `lock` directly to the uv entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)