### PR TITLE
fix(agent-image): native pinned uv relock + bump uv to 0.11.7

### DIFF
--- a/.github/workflows/agent-image-relock.yaml
+++ b/.github/workflows/agent-image-relock.yaml
@@ -1,12 +1,17 @@
 # .github/workflows/agent-image-relock.yaml
 #
-# Regenerates images/hermes-agent/uv.lock for a requested hermes-agent version
-# using the SAME pinned uv toolchain as `make agent-image-relock` (uv 0.5.0 in a
-# container), so contributors don't need Docker locally to bump the agent image.
+# Regenerates images/hermes-agent/uv.lock for a requested hermes-agent version,
+# so contributors don't need a local toolchain to bump the agent image.
+#
+# Runs pinned uv 0.5.0 (matching the Dockerfile's UV_VERSION, so the lock stays
+# compatible with `uv sync --frozen` at image-build time) directly on the runner,
+# which has git + a Python interpreter — both required to resolve the
+# `hermes-agent @ git+https://...` source dependency. (The astral uv container
+# image is distroless: no shell, git, or python, so it cannot resolve git deps.)
 #
 # Pushes the result to a branch `agent-image-relock-<version>`; open a PR from it
-# to main. Once merged, publish via the `agent-image` workflow (or an `agent/vX.Y.Z`
-# tag), which verifies the committed lock matches the requested version.
+# to main. Once merged, publish via the `agent-image` workflow (or an
+# `agent/vX.Y.Z` tag), which verifies the committed lock matches the version.
 name: agent-image-relock
 
 on:
@@ -27,8 +32,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Relock uv.lock (pinned uv via make agent-image-relock)
-        run: make agent-image-relock HERMES_VERSION="${{ inputs.hermes_version }}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv (pinned, in lockstep with the Dockerfile UV_VERSION)
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.7"
+
+      - name: Relock uv.lock for the requested hermes-agent version
+        working-directory: images/hermes-agent
+        env:
+          UV_FROZEN: "false" # pyproject sets frozen=true for builds; relock must write
+        run: |
+          set -eux
+          v="${{ inputs.hermes_version }}"
+          sed -i -E "s|(hermes-agent @ git\+https://github.com/NousResearch/hermes-agent@)[^\"]+|\1${v}|" pyproject.toml
+          uv lock
 
       - name: Push lockfile branch
         run: |

--- a/Makefile
+++ b/Makefile
@@ -150,14 +150,10 @@ agent-image-buildx:
 # ephemeral uv container so it works the same on developer laptops and in CI.
 # Requires network access to resolve the git dependency.
 .PHONY: agent-image-relock
-agent-image-relock:
+agent-image-relock: ## Relock images/hermes-agent/uv.lock for HERMES_VERSION. Requires local uv + git (resolves the git+https hermes-agent dep). CI alternative: run the agent-image-relock workflow (pins uv 0.5.0).
 	sed -i.bak -E 's|(hermes-agent @ git\+https://github.com/NousResearch/hermes-agent@)[^"]+|\1$(HERMES_VERSION)|' images/hermes-agent/pyproject.toml
 	rm -f images/hermes-agent/pyproject.toml.bak
-	docker run --rm \
-		-v $(PWD)/images/hermes-agent:/work \
-		-w /work \
-		ghcr.io/astral-sh/uv:0.5.0 \
-		lock
+	cd images/hermes-agent && UV_FROZEN=false uv lock
 	@echo "Updated images/hermes-agent/pyproject.toml and uv.lock for hermes-agent@$(HERMES_VERSION)"
 
 # Smoke-test a locally built image: --help should exit 0.

--- a/images/hermes-agent/Dockerfile
+++ b/images/hermes-agent/Dockerfile
@@ -10,14 +10,14 @@
 #                     Required. The CI workflow at .github/workflows/agent-image.yaml
 #                     drives this from a matrix.
 #   PYTHON_VERSION  : Python interpreter version. Default 3.11.
-#   UV_VERSION      : uv tool version. Default 0.5.0 (pinned for reproducibility).
+#   UV_VERSION      : uv tool version. Default 0.11.7 (pinned for reproducibility; keep in lockstep with the relock workflow).
 #   TINI_VERSION    : tini release tag (lesson openclaw #471: tini as PID 1).
 #
 # Output: a runtime image that, with no further configuration, runs
 #         `hermes-agent --config ~/.hermes/config.yaml` as UID 1000.
 
 ARG PYTHON_VERSION=3.11
-ARG UV_VERSION=0.5.0
+ARG UV_VERSION=0.11.7
 ARG TINI_VERSION=v0.19.0
 ARG HERMES_VERSION
 


### PR DESCRIPTION
Follow-up to #46. The relock still couldn't run: the `ghcr.io/astral-sh/uv` image is **distroless** (no shell, git, or python), so it can't resolve the `hermes-agent @ git+https://...` source dependency at all (`Could not read ELF interpreter …`).

- Run pinned uv **on the runner** (git + python present) with `UV_FROZEN=false` (pyproject sets `frozen=true` for builds; relock must be allowed to write the lock).
- **Bump uv `0.5.0` → `0.11.7`** in lockstep across the relock workflow and the Dockerfile `UV_VERSION`. The only constraint is relock-uv == build-uv (lockfile-format compatibility); since no lock/image has ever been published, there's no legacy to stay compatible with — no reason to stay on the old version.
- Makefile `agent-image-relock` target switched to native uv as well.

After merge: dispatch `agent-image-relock v0.13.0` → should now produce a real `uv.lock` → PR/merge it → publish → make package public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)