### PR TITLE
docs: point install instructions at working channels (fixes #43 chart-distribution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ in place from day one: no v0.x grind.
 ## Quickstart
 
 ```bash
-# 1. Install the CRDs and operator via Helm.
-helm repo add hermes https://paperclipinc.github.io/hermes-operator
-helm install hermes-operator hermes/hermes-operator \
+# 1. Install the CRDs and operator via Helm (OCI chart; Helm 3.8+).
+#    Omit --version for the latest release, or add --version X.Y.Z to pin.
+helm install hermes-operator \
+  oci://ghcr.io/paperclipinc/charts/hermes-operator \
   -n hermes-operator --create-namespace
 
 # 2. Apply a minimal instance.
@@ -43,7 +44,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true
@@ -53,7 +54,7 @@ YAML
 # 3. Watch it converge.
 kubectl get hi -n agents -w
 # NAME        READY   PHASE   IMAGE                                AGE
-# my-hermes   True    Ready   ghcr.io/paperclipinc/hermes-agent:1.4.2    30s
+# my-hermes   True    Ready   ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2    30s
 ```
 
 For more involved scenarios, see [`examples/`](examples/).
@@ -209,10 +210,10 @@ minor release. Patch releases never change the supported matrix.
 
 | Channel | What |
 |---|---|
-| Helm | `helm install hermes-operator hermes/hermes-operator` |
-| OLM / OperatorHub | `kubectl operator install hermes-operator` |
+| Helm (OCI) | `helm install hermes-operator oci://ghcr.io/paperclipinc/charts/hermes-operator` |
+| OLM / OperatorHub | `kubectl operator install hermes-operator` (pending first OperatorHub release) |
 | Plain manifests | `kubectl apply -f https://github.com/paperclipinc/hermes-operator/releases/latest/download/install.yaml` |
-| Container image | `ghcr.io/paperclipinc/hermes-operator:v1.0.0` (multi-arch, Cosign-signed, SBOM attested) |
+| Container image | `ghcr.io/paperclipinc/hermes-operator:v0.1.9` (multi-arch, Cosign-signed, SBOM attested) |
 
 ## Documentation
 

--- a/examples/auto-update/README.md
+++ b/examples/auto-update/README.md
@@ -34,8 +34,8 @@ kubectl apply -n agents -f hermesinstance.yaml
 ```bash
 kubectl get hi auto-update -n agents -w
 # NAME           READY   PHASE          IMAGE                                 AGE
-# auto-update    True    Ready          ghcr.io/paperclipinc/hermes-agent:1.4.2     2m
-# auto-update    False   Rolling        ghcr.io/paperclipinc/hermes-agent:1.4.2     3h
+# auto-update    True    Ready          ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2     2m
+# auto-update    False   Rolling        ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2     3h
 # auto-update    True    Ready          ghcr.io/paperclipinc/hermes-agent:1.4.3     3h1m
 
 kubectl get hi auto-update -n agents \

--- a/examples/auto-update/hermesinstance.yaml
+++ b/examples/auto-update/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/backup-s3/hermesinstance.yaml
+++ b/examples/backup-s3/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/cluster-defaults/README.md
+++ b/examples/cluster-defaults/README.md
@@ -44,7 +44,7 @@ spec:
 YAML
 
 kubectl get hi defaulted -n agents -o jsonpath='{.spec.image}'
-# {"repository":"ghcr.io/paperclipinc/hermes-agent","tag":"1.4.2"}
+# {"repository":"ghcr.io/paperclipinc/hermes-agent","tag":"v2026.5.29.2"}
 ```
 
 ## What this defaults
@@ -52,7 +52,7 @@ kubectl get hi defaulted -n agents -o jsonpath='{.spec.image}'
 | Spec path | Default |
 |---|---|
 | `spec.image.repository` | `ghcr.io/paperclipinc/hermes-agent` |
-| `spec.image.tag` | `1.4.2` |
+| `spec.image.tag` | `v2026.5.29.2` |
 | `spec.image.imagePullSecrets[]` | `[{name: ghcr-pull}]` |
 | `spec.storage.persistence.storageClassName` | `gp3` |
 | `spec.storage.persistence.size` | `10Gi` |

--- a/examples/cluster-defaults/clusterdefaults.yaml
+++ b/examples/cluster-defaults/clusterdefaults.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
     imagePullSecrets:
       - name: ghcr-pull
   registry:

--- a/examples/full-featured/hermesinstance.yaml
+++ b/examples/full-featured/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
     imagePullPolicy: IfNotPresent
     imagePullSecrets:
       - name: ghcr-pull
@@ -191,7 +191,7 @@ spec:
         effect: NoSchedule
   initContainers:
     - name: warm-cache
-      image: ghcr.io/paperclipinc/hermes-agent:1.4.2
+      image: ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2
       command: ["sh", "-c", "echo warming cache && sleep 2"]
   sidecars:
     - name: log-shipper

--- a/examples/gitops-fluxcd/hermesinstance.yaml
+++ b/examples/gitops-fluxcd/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/honcho/hermesinstance.yaml
+++ b/examples/honcho/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/migration-from-openclaw/from-backup.yaml
+++ b/examples/migration-from-openclaw/from-backup.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/migration-from-openclaw/from-sibling.yaml
+++ b/examples/migration-from-openclaw/from-sibling.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -16,7 +16,7 @@ kubectl apply -n agents -f hermesinstance.yaml
 ```bash
 kubectl get hi -n agents
 # NAME        READY   PHASE   IMAGE                                AGE
-# minimal     True    Ready   ghcr.io/paperclipinc/hermes-agent:1.4.2    30s
+# minimal     True    Ready   ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2    30s
 
 kubectl describe hi minimal -n agents | grep -A1 "Ready"
 # Type:   Ready

--- a/examples/minimal/hermesinstance.yaml
+++ b/examples/minimal/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true

--- a/examples/multi-platform/hermesinstance.yaml
+++ b/examples/multi-platform/hermesinstance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "1.4.2"
+    tag: "v2026.5.29.2"
   storage:
     persistence:
       enabled: true


### PR DESCRIPTION
Closes the chart-distribution half of #43 by making the docs match reality (no new Pages infra needed — the OCI chart already publishes and pulls anonymously).

- **Helm:** Quickstart + Distribution now use the working **OCI chart** `oci://ghcr.io/paperclipinc/charts/hermes-operator` instead of the non-existent `helm repo add … paperclipinc.github.io` (Pages isn't enabled → 404). Helm 3.8+/ArgoCD support OCI; omit `--version` for latest.
- **Real image versions:** `hermes-agent` tag `1.4.2` (never existed; upstream is CalVer) → `v2026.5.29.2` across README + examples; operator container image `v1.0.0` → `v0.1.9`.
- **OLM row** annotated as pending the first OperatorHub release (#8212/#8243 still open).
- The `Chart.yaml` vs release-tag mismatch is already resolved (both `0.1.9`). Honcho sidecar tags left as-is.

Optional follow-up if you want the classic `helm repo add` experience: wire up chart-releaser + enable Pages. Not done here since OCI already works.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)