### PR TITLE
fix(olm): correct CSV image refs so OperatorHub submission passes

### DIFF
--- a/bundle/manifests/hermes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hermes-operator.clusterserviceversion.yaml
@@ -1,12 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: 0.1.10
+  name: hermes-operator.v0.1.10
   namespace: placeholder
   annotations:
     capabilities: Auto Pilot
     categories: AI/Machine Learning, Developer Tools, Application Runtime
-    containerImage: 0.1.10
+    containerImage: ghcr.io/paperclipinc/hermes-operator:v0.1.10
     createdAt: '2026-05-12T00:00:00Z'
     support: paperclipinc
     repository: https://github.com/paperclipinc/hermes-operator
@@ -96,6 +96,9 @@ metadata:
     features.operators.openshift.io/token-auth-azure: 'false'
     features.operators.openshift.io/token-auth-gcp: 'false'
 spec:
+  icon:
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4IiByb2xlPSJpbWciIGFyaWEtbGFiZWw9Ikhlcm1lcyBPcGVyYXRvciI+CiAgPHJlY3Qgd2lkdGg9IjEyOCIgaGVpZ2h0PSIxMjgiIHJ4PSIyNCIgZmlsbD0iIzBCMTAyMCIvPgogIDxwYXRoIGQ9Ik00NCAzNnY1Nk04NCAzNnY1Nk00NCA2NGg0MCIgc3Ryb2tlPSIjNUI4REVGIiBzdHJva2Utd2lkdGg9IjEwIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8cGF0aCBkPSJNMzAgNTBjLTEwLTYtMjAtNi0yNi0yIDggMiAxNCA2IDE4IDEyek05OCA1MGMxMC02IDIwLTYgMjYtMi04IDItMTQgNi0xOCAxMnoiIGZpbGw9IiM3Q0UwQzMiLz4KPC9zdmc+Cg==
+      mediatype: image/svg+xml
   displayName: Hermes Operator
   description: >
     ## Hermes Kubernetes Operator
@@ -239,7 +242,7 @@ spec:
     - name: hermes-operator
       image: ghcr.io/paperclipinc/hermes-operator:v0.1.0
     - name: hermes-agent
-      image: ghcr.io/paperclipinc/hermes-agent:latest
+      image: ghcr.io/paperclipinc/hermes-agent:v2026.5.29.2
   customresourcedefinitions:
     owned:
       - name: hermesinstances.hermes.agent

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,8 +22,6 @@
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.version" },
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.appVersion" },
         { "type": "yaml", "path": "charts/hermes-operator/values.yaml", "jsonpath": "$.image.tag" },
-        { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.metadata.name" },
-        { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.metadata.annotations.containerImage" },
         { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.spec.version" }
       ]
     }


### PR DESCRIPTION
## Problem

Every hermes-operator OperatorHub submission (PRs #8212/#8243/#8272 in k8s-operatorhub/community-operators) fails the `kiwi / Full operator test` with:

```
Error: short-name resolution enforced but cannot prompt without a TTY
msg: Unable to pull 0.1.10, please check permissions or path.
```

The kiwi test pulls the image from the CSV `containerImage` annotation, which was the bare string `0.1.10` instead of `ghcr.io/paperclipinc/hermes-operator:v0.1.10`. `metadata.name` was likewise the bare `0.1.10` (flagged by the validator as not following `<operator>.v<semver>`).

## Root cause

`release-please-config.json` `extra-files` wrote the raw version into `$.metadata.name` and `$.metadata.annotations.containerImage` on every release, clobbering them to a bare version. (paperclip-operator works precisely because it lacks these entries.)

## Fix

- Remove those two `extra-files` entries (keep `$.spec.version`, which is correctly a bare semver).
- Set the source CSV to valid values; the submission workflow's existing `sed` rewrites both to the release tag, so kiwi can pull the operator image.
- Add `spec.icon` (clears the no-icon validator warning).
- Pin the `hermes-agent` relatedImage to `v2026.5.29.2` instead of `latest`.

`operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` now passes (only the informational `cronjobs` deprecated-api heuristic remains; minKubeVersion is 1.28).

Once merged and a release is cut, a fresh submission should pass kiwi. I'll close the stale community-operators PRs in favor of the clean one.