### PR TITLE
feat(chart): world-class Artifact Hub metadata + cosign chart signing

### DIFF
--- a/.github/workflows/operatorhub-submit.yaml
+++ b/.github/workflows/operatorhub-submit.yaml
@@ -80,10 +80,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch upstream main
-          git reset --hard upstream/main
-
-          git checkout -b "${BRANCH}"
+          FORK_OWNER=$(gh api user --jq '.login')
+          # Sync the fork's main with upstream SERVER-SIDE. gh repo sync is a
+          # fast-forward via the API; reset+push would carry upstream .github/workflows
+          # changes that a PAT without 'workflow' scope is refused.
+          gh repo sync "${FORK_OWNER}/community-operators" --branch main --force
+          git fetch origin main
+          git checkout -B "${BRANCH}" origin/main
 
           mkdir -p operators/hermes-operator
           cp -r ../submission/operators/hermes-operator/${VERSION} operators/hermes-operator/${VERSION}
@@ -180,9 +183,13 @@ jobs:
           cd community-operators-prod
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch upstream main
-          git reset --hard upstream/main
-          git checkout -b "${BRANCH}"
+          FORK_OWNER=$(gh api user --jq '.login')
+          # Sync the fork's main with upstream SERVER-SIDE. gh repo sync is a
+          # fast-forward via the API; reset+push would carry upstream .github/workflows
+          # changes that a PAT without 'workflow' scope is refused.
+          gh repo sync "${FORK_OWNER}/community-operators-prod" --branch main --force
+          git fetch origin main
+          git checkout -B "${BRANCH}" origin/main
           mkdir -p operators/hermes-operator
           cp -r ../submission/operators/hermes-operator/${VERSION} operators/hermes-operator/${VERSION}
           git add "operators/hermes-operator"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,11 +157,18 @@ jobs:
         with:
           version: latest
 
-      - name: Package and push Helm chart
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Package, push, and sign Helm chart
         run: |
           CHART_VERSION="${{ github.ref_name }}"
           CHART_VERSION="${CHART_VERSION#v}"
           helm package charts/hermes-operator \
             --version "${CHART_VERSION}" \
             --app-version "${{ github.ref_name }}"
-          helm push hermes-operator-${CHART_VERSION}.tgz oci://ghcr.io/paperclipinc/charts
+          PUSH_OUT=$(helm push "hermes-operator-${CHART_VERSION}.tgz" oci://ghcr.io/paperclipinc/charts 2>&1)
+          echo "${PUSH_OUT}"
+          DIGEST=$(echo "${PUSH_OUT}" | awk '/Digest:/ {print $2}')
+          if [ -z "${DIGEST}" ]; then echo "::error::could not parse chart digest"; exit 1; fi
+          cosign sign --yes "ghcr.io/paperclipinc/charts/hermes-operator@${DIGEST}"

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+# Artifact Hub repository metadata. After this chart repo is added under the
+# paperclipinc organization on artifacthub.io, paste the generated repositoryID
+# here (above owners) to claim verified ownership.
+owners:
+  - name: Jannes Stubbemann
+    email: jannes@paperclip.inc

--- a/charts/hermes-operator/Chart.yaml
+++ b/charts/hermes-operator/Chart.yaml
@@ -1,13 +1,77 @@
 apiVersion: v2
 name: hermes-operator
-description: Kubernetes operator for nousresearch/hermes-agent
+description: >-
+  A Kubernetes operator for deploying and managing Nous Research Hermes
+  AI agent instances
 type: application
 version: 0.1.14
 appVersion: 0.1.14
 kubeVersion: '>=1.28.0-0'
-home: https://github.com/paperclipinc/hermes-operator
+keywords:
+  - kubernetes
+  - operator
+  - hermes
+  - ai
+  - agent
+  - llm
+  - nous-research
+  - automation
+home: https://paperclip.inc
+icon: https://paperclip.inc/favicon.svg
 sources:
   - https://github.com/paperclipinc/hermes-operator
 maintainers:
   - name: paperclipinc
     email: jannes@paperclip.inc
+annotations:
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/operator: 'true'
+  artifacthub.io/operatorCapabilities: Seamless Upgrades
+  artifacthub.io/prerelease: 'false'
+  artifacthub.io/links: |
+    - name: Website
+      url: https://paperclip.inc
+    - name: Documentation
+      url: https://paperclip.inc/docs/operators/hermes
+    - name: OperatorHub
+      url: https://artifacthub.io/packages/olm/community-operators/hermes-operator
+    - name: support
+      url: https://github.com/paperclipinc/hermes-operator/issues
+  artifacthub.io/crds: |
+    - kind: HermesInstance
+      version: v1
+      name: hermesinstances.hermes.agent
+      displayName: Hermes Instance
+      description: Represents a managed Nous Research Hermes AI agent instance
+    - kind: HermesSelfConfig
+      version: v1
+      name: hermesselfconfigs.hermes.agent
+      displayName: Hermes Self-Config
+      description: A request from an agent to modify its own HermesInstance spec
+    - kind: HermesClusterDefaults
+      version: v1
+      name: hermesclusterdefaults.hermes.agent
+      displayName: Hermes Cluster Defaults
+      description: Cluster-wide default settings applied to Hermes instances
+  artifacthub.io/crdsExamples: |
+    - apiVersion: hermes.agent/v1
+      kind: HermesInstance
+      metadata:
+        name: my-hermes
+      spec:
+        image:
+          repository: ghcr.io/paperclipinc/hermes-agent
+          tag: v2026.5.29.2
+        storage:
+          persistence:
+            enabled: true
+            size: 10Gi
+  artifacthub.io/images: |
+    - name: hermes-operator
+      image: ghcr.io/paperclipinc/hermes-operator:0.1.14 # x-release-please-version
+  artifacthub.io/changes: |
+    - kind: added
+      description: World-class Artifact Hub metadata (logo, keywords, CRDs, images)
+    - kind: added
+      description: Helm chart OCI artifact is now cosign-signed (keyless)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,7 +22,8 @@
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.version" },
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.appVersion" },
         { "type": "yaml", "path": "charts/hermes-operator/values.yaml", "jsonpath": "$.image.tag" },
-        { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.spec.version" }
+        { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.spec.version" },
+        { "type": "generic", "path": "charts/hermes-operator/Chart.yaml" }
       ]
     }
   }


### PR DESCRIPTION
Brings hermes-operator's Helm chart to the same world-class bar as openclaw-operator.

## Changes
- **Rich Chart.yaml metadata** — logo/icon, keywords, category, license, links, CRDs (HermesInstance/SelfConfig/ClusterDefaults, `v1`), crdsExamples, `artifacthub.io/images` (auto-bumping via `# x-release-please-version` + release-please generic updater), `artifacthub.io/changes`.
- **`artifacthub-repo.yml`** added (ready to claim verified ownership under the paperclipinc org).
- **Chart cosign signing** — `helm-release` keyless-signs the pushed chart artifact.
- **OperatorHub submit hardened** — both `community-operators` and `community-operators-prod` jobs sync the fork via `gh repo sync` (avoids the `workflow`-scope push rejection).

Verified: `helm lint` passes; rendered image tag == `artifacthub.io/images` (`0.1.14`); CRD version `v1` confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)