### PR TITLE
fix(bundle): declare com.redhat.openshift.versions for OpenShift cert

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: hermes-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
+  com.redhat.openshift.versions: "v4.15"


### PR DESCRIPTION
OpenShift community-operators-prod validation fails: minKubeVersion 1.28.0 but com.redhat.openshift.versions not set. Declares v4.15 (k8s 1.28 -> OCP 4.15).