### PR TITLE
fix(operatorhub): ship ci.yaml to redhat submission + add reviewers

### DIFF
--- a/.github/workflows/operatorhub-submit.yaml
+++ b/.github/workflows/operatorhub-submit.yaml
@@ -170,6 +170,8 @@ jobs:
           cp bundle/manifests/hermes.agent_hermesselfconfigs.yaml    "${BUNDLE_DIR}/manifests/"
           cp bundle/manifests/hermes.agent_hermesclusterdefaults.yaml "${BUNDLE_DIR}/manifests/"
           cp bundle/metadata/annotations.yaml "${BUNDLE_DIR}/metadata/"
+          # Per community-operators convention, copy ci.yaml alongside.
+          cp bundle/ci.yaml "submission/operators/hermes-operator/" || true
 
       - name: Fork and submit to redhat community-operators-prod
         env:
@@ -192,6 +194,10 @@ jobs:
           git checkout -B "${BRANCH}" origin/main
           mkdir -p operators/hermes-operator
           cp -r ../submission/operators/hermes-operator/${VERSION} operators/hermes-operator/${VERSION}
+          # Only seed ci.yaml when the catalog does not already have one. Overwriting
+          # it on every release is a privileged change that withholds the
+          # authorized-changes label and blocks auto-merge.
+          [ -f operators/hermes-operator/ci.yaml ] || cp ../submission/operators/hermes-operator/ci.yaml operators/hermes-operator/ci.yaml 2>/dev/null || true
           git add "operators/hermes-operator"
           git commit -m "operator hermes-operator (${VERSION})"
           git push --force origin "${BRANCH}"

--- a/bundle/ci.yaml
+++ b/bundle/ci.yaml
@@ -1,2 +1,5 @@
 index_images: registry.redhat.io/redhat/community-operator-index:v4.15
 updateGraph: semver-mode
+# A PR authored by a listed reviewer auto-gets the `authorized-changes` label (enables auto-merge).
+reviewers:
+  - stubbi


### PR DESCRIPTION
## Summary

- Adds `reviewers: [stubbi]` to `bundle/ci.yaml`, which already had `index_images:` and `updateGraph: semver-mode`. Preserves both existing fields.
- Mirrors the k8s job's ci.yaml staging (`cp bundle/ci.yaml submission/operators/hermes-operator/`) and seed-if-absent logic into the `submit-redhat` (community-operators-prod) job, which previously omitted `ci.yaml` entirely.
- Result: both submission jobs now ship a complete `operators/hermes-operator/ci.yaml` containing `updateGraph: semver-mode` + `reviewers: stubbi`.
- Clears the `check_ci_upgrade_graph` warning on both OperatorHub and community-operators-prod.

## Test plan

- [ ] Trigger `OperatorHub Submission` workflow dispatch — verify both jobs include `operators/hermes-operator/ci.yaml` with `updateGraph: semver-mode` and `reviewers: [stubbi]`.
- [ ] Confirm `bundle/ci.yaml` still has `index_images:` preserved: `yq '.index_images' bundle/ci.yaml`.
- [ ] Confirm workflow YAML parses: `yq '.jobs|keys' .github/workflows/operatorhub-submit.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)