### PR TITLE
fix(agent-image): ship pyproject.toml + uv.lock at /opt/venv-template/ (#68)

### DIFF
--- a/images/hermes-agent/Dockerfile
+++ b/images/hermes-agent/Dockerfile
@@ -87,6 +87,15 @@ RUN groupadd --system --gid 1000 hermes \
 
 # Copy the resolved venv from the builder stage.
 COPY --from=builder --chown=hermes:hermes /opt/venv /opt/venv
+
+# Ship the lockfile + project metadata at /opt/venv-template/ as well. The
+# operator's `init-uv` init container (internal/resources/runtime_init.go) does
+#   cd /home/hermes/.hermes; cp /opt/venv-template/pyproject.toml /opt/venv-template/uv.lock .; uv sync --frozen
+# to materialise the env into the per-instance PVC. Without these files the init
+# container exits 1 ("cp: cannot stat '/opt/venv-template/pyproject.toml'") and
+# no HermesInstance ever reaches Ready. See #68.
+COPY --from=builder --chown=hermes:hermes /build/pyproject.toml /build/uv.lock /opt/venv-template/
+
 ENV PATH="/opt/venv/bin:${PATH}" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Problem

Every `HermesInstance` fails to reach `Ready` because the operator's `init-uv` init container is incompatible with the published `ghcr.io/paperclipinc/hermes-agent` image (issue #68, confirmed by multiple users).

`internal/resources/runtime_init.go` renders:

```
set -eu; cd /home/hermes/.hermes; \
  cp /opt/venv-template/pyproject.toml /opt/venv-template/uv.lock .; \
  uv sync --frozen
```

…but `images/hermes-agent/Dockerfile` builds the venv at `/opt/venv` and copies **nothing** to `/opt/venv-template/`. So `init-uv` exits 1:

```
cp: cannot stat '/opt/venv-template/pyproject.toml': No such file or directory
```

…the `hermes` container never starts, the StatefulSet never reaches `readyReplicas == replicas`, and the instance never becomes `Ready=True`.

## Fix

Add one `COPY` to the runtime stage shipping the lockfile + project metadata at `/opt/venv-template/`, exactly where the operator's contract expects them. The files already exist at `/build/` in the builder stage.

## Scope

Minimal, surgical fix — Dockerfile only. No change to the build/sign/SBOM/multi-arch pipeline.

## Follow-up

Once a fixed agent image is republished, un-skip the `#68`-gated specs in `test/conformance/idempotency_test.go` (`idempotencyImageContractSkip`).

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)