### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1 and mkdocs-material to 9.7.7

### DIFF
--- a/docs-site/requirements.txt
+++ b/docs-site/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.49
-pymdown-extensions==10.21.3
+mkdocs-material==9.7.7
+pymdown-extensions==11.0.1


### PR DESCRIPTION
## Summary

Supersedes #119. Dependabot proposed bumping `pymdown-extensions` 10.21.3 → 11.0 on its own, which cannot install:

```
ERROR: Cannot install -r docs-site/requirements.txt (line 2) and pymdown-extensions==11.0
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

`mkdocs-material==9.5.49` declares `pymdown-extensions~=10.2`, which excludes 11.x. `mkdocs-material` 9.7.7 relaxes this to `pymdown-extensions>=10.2`, so the two have to move together.

## Changes

- `mkdocs-material` 9.5.49 → 9.7.7
- `pymdown-extensions` 10.21.3 → 11.0.1 (11.0.1 is current; 11.0 has since been superseded)

## Verification

Built in a clean venv against the new pins:

```
$ mkdocs build --strict
INFO - Documentation built in 1.13 seconds
```

No theme overrides or plugin config needed changes.