### PR TITLE
fix(chart): render pullable default image tags

### DIFF
--- a/.github/workflows/agent-image-relock.yaml
+++ b/.github/workflows/agent-image-relock.yaml
@@ -18,9 +18,9 @@ on:
   workflow_dispatch:
     inputs:
       hermes_version:
-        description: "hermes-agent release tag to lock (e.g. v0.13.0)"
+        description: "hermes-agent release tag to lock (e.g. v0.16.0)"
         required: true
-        default: "v0.13.0"
+        default: "v0.16.0"
         type: string
 
 permissions:

--- a/.github/workflows/helm-rbac.yaml
+++ b/.github/workflows/helm-rbac.yaml
@@ -20,3 +20,11 @@ jobs:
       - uses: actions/checkout@v7
       - run: sudo snap install yq
       - run: make sync-bundle-rbac-check
+
+  chart-image-tags:
+    name: Chart Image Tags Resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: azure/setup-helm@v5
+      - run: bash hack/check-chart-image-tags.sh

--- a/charts/hermes-operator/Chart.yaml
+++ b/charts/hermes-operator/Chart.yaml
@@ -69,7 +69,7 @@ annotations:
             size: 10Gi
   artifacthub.io/images: |
     - name: hermes-operator
-      image: ghcr.io/paperclipinc/hermes-operator:0.1.18 # x-release-please-version
+      image: ghcr.io/paperclipinc/hermes-operator:v0.1.18 # x-release-please-version
   artifacthub.io/changes: |
     - kind: added
       description: World-class Artifact Hub metadata (logo, keywords, CRDs, images)

--- a/charts/hermes-operator/values.yaml
+++ b/charts/hermes-operator/values.yaml
@@ -1,6 +1,9 @@
 image:
   repository: ghcr.io/paperclipinc/hermes-operator
-  tag: 0.1.18
+  # Leave empty to track the chart's appVersion. The release workflow publishes
+  # v-prefixed image tags, so _helpers.tpl falls back to "v<appVersion>".
+  # Pinning a bare version here yields an unpullable reference (see #113).
+  tag: ""
   pullPolicy: IfNotPresent
 logLevel: info
 createRBAC: true
@@ -23,10 +26,11 @@ webhook:
     issuerName: hermes-operator-selfsigned
   caBundle: ''
   servingCertSecretName: hermes-operator-webhook-server-cert
-agentImage:
-  repository: ghcr.io/paperclipinc/hermes-agent
-  tag: v0.13.0
-  pullPolicy: IfNotPresent
+# NOTE: there is deliberately no agentImage default here. The agent image is
+# chosen per-instance via HermesInstance.spec.image, and the CRD requires an
+# explicit tag or digest (pinning a floating tag can silently pull a broken
+# upstream build). A chart-level default was vestigial — nothing rendered it —
+# and advertised an unpublished tag. See #113.
 honchoImage:
   repository: ghcr.io/plastic-labs/honcho
   tag: 0.1.0

--- a/hack/check-chart-image-tags.sh
+++ b/hack/check-chart-image-tags.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Assert that every image reference the chart renders at its own defaults is
+# actually pullable from the registry.
+#
+# Regression guard for #113: release-please used to write a bare version into
+# values.yaml `image.tag` while the release workflow only publishes v-prefixed
+# tags, so `helm install` at the chart's own defaults produced ImagePullBackOff.
+#
+# Uses the anonymous registry token + manifest HEAD, so it needs no credentials
+# for public images.
+set -euo pipefail
+
+CHART_DIR="${CHART_DIR:-charts/hermes-operator}"
+APP_VERSION="$(sed -nE 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?/\1/p' "${CHART_DIR}/Chart.yaml")"
+
+fail=0
+
+# Resolve a ghcr.io reference to a manifest, following the OCI auth dance.
+check_ref() {
+  local ref="$1"
+  local repo tag host path token code
+
+  host="${ref%%/*}"
+  path="${ref#*/}"
+  repo="${path%:*}"
+  tag="${path##*:}"
+
+  if [[ "$host" != "ghcr.io" ]]; then
+    echo "  SKIP $ref (only ghcr.io is checked)"
+    return 0
+  fi
+
+  # The operator image is only ever published v-prefixed. A bare semver here is
+  # the #113 regression: it renders an unpullable reference. Catch it by shape,
+  # so it fails even before the tag would have had a chance to exist.
+  if [[ "$repo" == "paperclipinc/hermes-operator" && "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "  FAIL $ref (bare version tag; the release workflow publishes v${tag})"
+    fail=1
+    return 0
+  fi
+
+  # The operator image is published by the release workflow, which runs *after*
+  # release-please bumps appVersion. On a release PR (and on main until the
+  # release job finishes) the chart legitimately renders a tag that does not
+  # exist yet. Exempt exactly that case from the existence check, but still
+  # enforce the v-prefix format that #113 was about.
+  if [[ "$repo" == "paperclipinc/hermes-operator" && "$tag" == "v${APP_VERSION}" ]]; then
+    if ! git rev-parse -q --verify "refs/tags/v${APP_VERSION}" >/dev/null 2>&1; then
+      echo "  SKIP $ref (v${APP_VERSION} is the pending release; format is correct)"
+      return 0
+    fi
+  fi
+
+  token=$(curl -fsSL "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+
+  code=$(curl -s -o /dev/null -w '%{http_code}' -I \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+    -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+    -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/${repo}/manifests/${tag}")
+
+  if [[ "$code" == "200" ]]; then
+    echo "  OK   $ref"
+  else
+    echo "  FAIL $ref (HTTP $code — tag does not resolve)"
+    fail=1
+  fi
+}
+
+echo "Rendering ${CHART_DIR} at its defaults..."
+refs=$(helm template hermes-operator "${CHART_DIR}" \
+  | grep -oE 'image: "?[a-z0-9./-]+:[A-Za-z0-9._-]+"?' \
+  | sed -E 's/^image: "?//; s/"?$//' \
+  | sort -u)
+
+if [[ -z "$refs" ]]; then
+  echo "ERROR: no image references found in rendered chart — check the grep." >&2
+  exit 1
+fi
+
+echo "Checking rendered image references:"
+while IFS= read -r ref; do
+  [[ -n "$ref" ]] && check_ref "$ref"
+done <<<"$refs"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo
+  echo "One or more chart default image tags are unpullable." >&2
+  echo "The release workflow publishes v-prefixed tags (v<version>), so the" >&2
+  echo "chart must render those — see hack/check-chart-image-tags.sh header." >&2
+  exit 1
+fi
+
+echo "All chart default image tags resolve."

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,6 @@
       "extra-files": [
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.version" },
         { "type": "yaml", "path": "charts/hermes-operator/Chart.yaml", "jsonpath": "$.appVersion" },
-        { "type": "yaml", "path": "charts/hermes-operator/values.yaml", "jsonpath": "$.image.tag" },
         { "type": "yaml", "path": "bundle/manifests/hermes-operator.clusterserviceversion.yaml", "jsonpath": "$.spec.version" },
         { "type": "generic", "path": "charts/hermes-operator/Chart.yaml" }
       ]

--- a/test/e2e/testdata/hermesinstance-gateways.yaml
+++ b/test/e2e/testdata/hermesinstance-gateways.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "v0.13.0"
+    tag: "v0.16.0"
     pullPolicy: IfNotPresent
   storage:
     persistence:

--- a/test/e2e/testdata/hermesinstance-tailscale.yaml
+++ b/test/e2e/testdata/hermesinstance-tailscale.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/paperclipinc/hermes-agent
-    tag: "v0.13.0"
+    tag: "v0.16.0"
     pullPolicy: IfNotPresent
   storage:
     persistence:


### PR DESCRIPTION
Fixes #113.

## Root cause

`release-please-config.json` had a `$.image.tag` updater writing the **bare** version into `values.yaml`:

```yaml
image:
  tag: 0.1.18   # <- unpullable
```

but the release workflow only ever publishes **v-prefixed** tags. `Compute image tags` in `release.yaml` pushes `${TAG}` (= `v0.1.18`), `${MAJOR_MINOR}` (= `0.1`) and `latest` — never a bare `0.1.18`.

`_helpers.tpl:16` already had the right fallback:

```
{{- $tag := default (printf "v%s" .Chart.AppVersion) .Values.image.tag -}}
```

It just never fired, because release-please kept the value populated. So this is fixed at the source rather than by hardcoding a `v`.

## Changes

| | |
|---|---|
| `values.yaml` | `image.tag: ""` — chart now tracks `v<appVersion>` via the existing fallback |
| `release-please-config.json` | drop the `$.image.tag` updater that repopulated it (`appVersion` stays managed) |
| `Chart.yaml` | `artifacthub.io/images` -> `v0.1.18`; the `x-release-please-version` annotation preserves the `v` on future bumps |
| `values.yaml` | remove the vestigial `agentImage` block (see below) |
| e2e fixtures, relock workflow | `v0.13.0` -> `v0.16.0` |
| `hack/check-chart-image-tags.sh` + CI job | regression guard |

## On part 2 of the issue (`agentImage.tag: v0.13.0`)

The reported tag is genuinely stale, but the described mechanism is slightly different from the report: a minimal `HermesInstance` does **not** silently render `hermes-agent:v0.13.0`. Nothing reads `agentImage` — it appears in no template and no Go code:

```
$ grep -rn "agentImage" . --exclude-dir=site --exclude-dir=.git
charts/hermes-operator/values.yaml:29:agentImage:
docs/superpowers/plans/...-plan-3-hermes-runtime.md:4026:agentImage:
```

The agent image comes from `HermesInstance.spec.image`, and the CRD has no default for `tag` plus a CEL rule requiring tag-or-digest, so an instance without an image is *rejected*, not defaulted. The `agentImage` block was therefore dead config advertising a tag that was never published — removed rather than bumped.

## Regression guard

`hack/check-chart-image-tags.sh` renders the chart at its defaults and HEADs each `ghcr.io` manifest with an anonymous pull token. Verified against four scenarios:

| scenario | exit |
|---|---|
| A — fixed values, `v0.1.18` released | `0` |
| B — the #113 regression (bare `0.1.18`) | `1` |
| C — release PR, `appVersion` 0.1.19 not yet tagged | `0` (skipped, format still enforced) |
| D — restored | `0` |

Scenario C matters: on a release PR the chart legitimately renders a tag that does not exist until the release job runs, so the existence check is exempted for exactly the pending version while the `v`-prefix shape is still enforced. Scenario B is checked by shape, so it fails immediately rather than depending on registry state.

`helm lint` passes; rendered operator image is now `ghcr.io/paperclipinc/hermes-operator:v0.1.18`, which resolves.

## Follow-up (not in this PR)

- `honchoImage` in `values.yaml` is dead in the same way as `agentImage` was.
- The bundle CSV is stale independently of release-please: `containerImage: ...:v0.1.10` and two `image: ...:v0.1.0` entries.

I'll file both separately.