### PR TITLE
feat(scheduling): add spec.scheduling.runtimeClassName

### DIFF
--- a/api/v1/hermesinstance_types.go
+++ b/api/v1/hermesinstance_types.go
@@ -847,6 +847,17 @@ type SchedulingSpec struct {
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// RuntimeClassName selects the RuntimeClass the instance pod runs under,
+	// so an agent executing model-driven code can be placed on a sandboxed
+	// runtime (gVisor "runsc", Kata) instead of the cluster default.
+	//
+	// The named RuntimeClass must already exist in the cluster; an unknown name
+	// leaves the pod unschedulable. Empty means the cluster default runtime.
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +optional
+	RuntimeClassName string `json:"runtimeClassName,omitempty"`
 }
 
 // InstanceSkill: Plan 3 fills the runtime semantics. The field exists here so

--- a/bundle/manifests/hermes.agent_hermesinstances.yaml
+++ b/bundle/manifests/hermes.agent_hermesinstances.yaml
@@ -4641,6 +4641,66 @@ spec:
               networking:
                 description: Networking exposes the agent via Service / Ingress.
                 properties:
+                  httpRoute:
+                    description: |-
+                      HTTPRoute controls optional Gateway API HTTPRoute creation. The operator
+                      emits an unstructured gateway.networking.k8s.io/v1 HTTPRoute; the Gateway
+                      API CRDs must be installed in the cluster for this to take effect.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations are applied verbatim onto the HTTPRoute.
+                        type: object
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled: when true, the operator creates an HTTPRoute for the agent.
+                          Default false.
+                        type: boolean
+                      hostnames:
+                        description: Hostnames are the hostnames matched by this route.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      parentRefs:
+                        description: |-
+                          ParentRefs are the Gateways (or other parents) this route attaches to.
+                          At least one is required for the route to take effect.
+                        items:
+                          description: HTTPRouteParentRef references a parent (typically
+                            a Gateway) the route attaches to.
+                          properties:
+                            name:
+                              description: Name of the parent resource (e.g. the Gateway
+                                name).
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: Namespace of the parent. Defaults to the
+                                HermesInstance namespace when empty.
+                              type: string
+                            sectionName:
+                              description: SectionName is the name of a section within
+                                the parent (e.g. a Gateway listener).
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      path:
+                        default: /
+                        description: Path is the path prefix routed to the agent Service.
+                          Default "/".
+                        type: string
+                      servicePortName:
+                        default: gateway
+                        description: |-
+                          ServicePortName: name of the Service port the route should target.
+                          Default "gateway".
+                        type: string
+                    type: object
                   ingress:
                     description: Ingress controls optional Ingress creation.
                     properties:
@@ -5540,9 +5600,15 @@ spec:
                 type: string
               runtime:
                 description: |-
-                  Runtime controls the agent's Python toolchain and OS-level dependencies.
-                  All fields default to the values that match the operator's published
-                  ghcr.io/paperclipinc/hermes-agent image.
+                  Runtime configured the agent's Python toolchain and OS-level dependencies
+                  for the old hand-rolled agent image. It is now IGNORED: the published agent
+                  image is the upstream NousResearch/hermes-agent s6 runtime, which ships its
+                  own Python env, browser, node, and dependencies (see docs/runtime.md), so
+                  the operator no longer builds a runtime via init containers. Setting this
+                  has no effect.
+
+                  Deprecated: ignored since the upstream-image runtime (v0.1.19); scheduled
+                  for removal no earlier than v0.3.0 and 2027-01-01. See docs/deprecations.md.
                 properties:
                   extraAptPackages:
                     description: |-
@@ -6581,6 +6647,17 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  runtimeClassName:
+                    description: |-
+                      RuntimeClassName selects the RuntimeClass the instance pod runs under,
+                      so an agent executing model-driven code can be placed on a sandboxed
+                      runtime (gVisor "runsc", Kata) instead of the cluster default.
+
+                      The named RuntimeClass must already exist in the cluster; an unknown name
+                      leaves the pod unschedulable. Empty means the cluster default runtime.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   tolerations:
                     items:
                       description: |-
@@ -7370,19 +7447,18 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
               shareProcessNamespace:
-                default: true
+                default: false
                 description: |-
                   ShareProcessNamespace enables PID namespace sharing between all containers
-                  in the pod. When true (the default), the infrastructure (pause) container
-                  becomes PID 1 and reaps zombie processes, preventing accumulation of defunct
-                  helper processes (git, plugins, shells) spawned under the agent entrypoint
-                  when it does not call waitpid().
+                  in the pod. Defaults to false: the upstream hermes-agent image runs under
+                  s6-overlay, whose /init must be PID 1 (s6-overlay-suexec aborts otherwise),
+                  and s6 already reaps zombies non-blocking on SIGCHLD — so sharing the process
+                  namespace (which makes the pause container PID 1) is both incompatible and
+                  unnecessary.
 
                   Security note: enabling this lets every container in the pod see and signal
                   every other container's processes. A compromised sidecar could send signals
-                  to the agent and vice versa. Set to false to keep per-container PID isolation;
-                  you are then responsible for reaping zombies (e.g. by baking tini or dumb-init
-                  into the image).
+                  to the agent and vice versa. Leave false to keep per-container PID isolation.
                 type: boolean
               sidecars:
                 description: |-
@@ -8953,6 +9029,134 @@ spec:
                 description: Suspended scales the StatefulSet to zero replicas without
                   deleting state.
                 type: boolean
+              tailscale:
+                description: Tailscale exposes the gateway over a Tailscale tailnet.
+                properties:
+                  authKey:
+                    description: |-
+                      AuthKey references the Secret holding a reusable, ephemeral Tailscale auth
+                      key, exposed to the sidecar as TS_AUTHKEY. Required when Enabled is true.
+                    properties:
+                      secretRef:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  enabled:
+                    default: false
+                    description: Enabled turns on the operator-managed Tailscale sidecar.
+                    type: boolean
+                  hostname:
+                    description: Hostname overrides the tailnet/MagicDNS hostname.
+                      Defaults to metadata.name.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                    type: string
+                  image:
+                    description: Image overrides the tailscale sidecar image.
+                    properties:
+                      pullPolicy:
+                        default: IfNotPresent
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      repository:
+                        default: tailscale/tailscale
+                        type: string
+                      tag:
+                        default: v1.86.2
+                        type: string
+                    type: object
+                  mode:
+                    default: serve
+                    description: |-
+                      Mode selects how the gateway is exposed over the tailnet. Only "serve"
+                      is implemented today (private tailnet exposure with a Tailscale TLS cert).
+                    enum:
+                    - serve
+                    type: string
+                  resources:
+                    description: Resources sets the sidecar resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
               workspace:
                 description: Workspace seeds initial files and directories into ~/.hermes
                   on first start.

--- a/charts/hermes-operator/templates/crds/hermes.agent_hermesinstances.yaml
+++ b/charts/hermes-operator/templates/crds/hermes.agent_hermesinstances.yaml
@@ -5602,8 +5602,10 @@ spec:
                 description: |-
                   Runtime configured the agent's Python toolchain and OS-level dependencies
                   for the old hand-rolled agent image. It is now IGNORED: the published agent
-                  image is the upstream NousResearch/hermes-agent s6 runtime, which is
-                  self-contained (see docs/runtime.md). Setting this has no effect.
+                  image is the upstream NousResearch/hermes-agent s6 runtime, which ships its
+                  own Python env, browser, node, and dependencies (see docs/runtime.md), so
+                  the operator no longer builds a runtime via init containers. Setting this
+                  has no effect.
 
                   Deprecated: ignored since the upstream-image runtime (v0.1.19); scheduled
                   for removal no earlier than v0.3.0 and 2027-01-01. See docs/deprecations.md.
@@ -6645,6 +6647,17 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  runtimeClassName:
+                    description: |-
+                      RuntimeClassName selects the RuntimeClass the instance pod runs under,
+                      so an agent executing model-driven code can be placed on a sandboxed
+                      runtime (gVisor "runsc", Kata) instead of the cluster default.
+
+                      The named RuntimeClass must already exist in the cluster; an unknown name
+                      leaves the pod unschedulable. Empty means the cluster default runtime.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   tolerations:
                     items:
                       description: |-
@@ -7437,16 +7450,15 @@ spec:
                 default: false
                 description: |-
                   ShareProcessNamespace enables PID namespace sharing between all containers
-                  in the pod. When true (the default), the infrastructure (pause) container
-                  becomes PID 1 and reaps zombie processes, preventing accumulation of defunct
-                  helper processes (git, plugins, shells) spawned under the agent entrypoint
-                  when it does not call waitpid().
+                  in the pod. Defaults to false: the upstream hermes-agent image runs under
+                  s6-overlay, whose /init must be PID 1 (s6-overlay-suexec aborts otherwise),
+                  and s6 already reaps zombies non-blocking on SIGCHLD — so sharing the process
+                  namespace (which makes the pause container PID 1) is both incompatible and
+                  unnecessary.
 
                   Security note: enabling this lets every container in the pod see and signal
                   every other container's processes. A compromised sidecar could send signals
-                  to the agent and vice versa. Set to false to keep per-container PID isolation;
-                  you are then responsible for reaping zombies (e.g. by baking tini or dumb-init
-                  into the image).
+                  to the agent and vice versa. Leave false to keep per-container PID isolation.
                 type: boolean
               sidecars:
                 description: |-

--- a/config/crd/bases/hermes.agent_hermesinstances.yaml
+++ b/config/crd/bases/hermes.agent_hermesinstances.yaml
@@ -5602,8 +5602,10 @@ spec:
                 description: |-
                   Runtime configured the agent's Python toolchain and OS-level dependencies
                   for the old hand-rolled agent image. It is now IGNORED: the published agent
-                  image is the upstream NousResearch/hermes-agent s6 runtime, which is
-                  self-contained (see docs/runtime.md). Setting this has no effect.
+                  image is the upstream NousResearch/hermes-agent s6 runtime, which ships its
+                  own Python env, browser, node, and dependencies (see docs/runtime.md), so
+                  the operator no longer builds a runtime via init containers. Setting this
+                  has no effect.
 
                   Deprecated: ignored since the upstream-image runtime (v0.1.19); scheduled
                   for removal no earlier than v0.3.0 and 2027-01-01. See docs/deprecations.md.
@@ -6645,6 +6647,17 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  runtimeClassName:
+                    description: |-
+                      RuntimeClassName selects the RuntimeClass the instance pod runs under,
+                      so an agent executing model-driven code can be placed on a sandboxed
+                      runtime (gVisor "runsc", Kata) instead of the cluster default.
+
+                      The named RuntimeClass must already exist in the cluster; an unknown name
+                      leaves the pod unschedulable. Empty means the cluster default runtime.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   tolerations:
                     items:
                       description: |-
@@ -7437,16 +7450,15 @@ spec:
                 default: false
                 description: |-
                   ShareProcessNamespace enables PID namespace sharing between all containers
-                  in the pod. When true (the default), the infrastructure (pause) container
-                  becomes PID 1 and reaps zombie processes, preventing accumulation of defunct
-                  helper processes (git, plugins, shells) spawned under the agent entrypoint
-                  when it does not call waitpid().
+                  in the pod. Defaults to false: the upstream hermes-agent image runs under
+                  s6-overlay, whose /init must be PID 1 (s6-overlay-suexec aborts otherwise),
+                  and s6 already reaps zombies non-blocking on SIGCHLD — so sharing the process
+                  namespace (which makes the pause container PID 1) is both incompatible and
+                  unnecessary.
 
                   Security note: enabling this lets every container in the pod see and signal
                   every other container's processes. A compromised sidecar could send signals
-                  to the agent and vice versa. Set to false to keep per-container PID isolation;
-                  you are then responsible for reaping zombies (e.g. by baking tini or dumb-init
-                  into the image).
+                  to the agent and vice versa. Leave false to keep per-container PID isolation.
                 type: boolean
               sidecars:
                 description: |-

--- a/docs/api-reference-generated.md
+++ b/docs/api-reference-generated.md
@@ -1150,6 +1150,7 @@ _Appears in:_
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core) array_ |  |  | Optional: \{\} <br /> |
 | `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core)_ |  |  | Optional: \{\} <br /> |
 | `priorityClassName` _string_ |  |  | Optional: \{\} <br /> |
+| `runtimeClassName` _string_ | RuntimeClassName selects the RuntimeClass the instance pod runs under,<br />so an agent executing model-driven code can be placed on a sandboxed<br />runtime (gVisor "runsc", Kata) instead of the cluster default.<br />The named RuntimeClass must already exist in the cluster; an unknown name<br />leaves the pod unschedulable. Empty means the cluster default runtime. |  | MaxLength: 253 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Optional: \{\} <br /> |
 
 
 #### SecurityDefaults

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -203,6 +203,7 @@ func BuildStatefulSet(inst *hermesv1.HermesInstance, extraInits []corev1.Contain
 		Tolerations:                   inst.Spec.Scheduling.Tolerations,
 		Affinity:                      inst.Spec.Scheduling.Affinity,
 		PriorityClassName:             inst.Spec.Scheduling.PriorityClassName,
+		RuntimeClassName:              runtimeClassName(inst),
 		TopologySpreadConstraints:     inst.Spec.Availability.TopologySpreadConstraints,
 		ServiceAccountName:            ServiceAccountNameFor(inst),
 		Containers:                    []corev1.Container{c},
@@ -342,6 +343,17 @@ func shareProcessNamespace(inst *hermesv1.HermesInstance) *bool {
 		return inst.Spec.ShareProcessNamespace
 	}
 	return Ptr(false)
+}
+
+// runtimeClassName maps the spec field onto the pod's optional
+// RuntimeClassName. Unset must stay nil rather than a pointer to "": an empty
+// string is not the cluster default, it is a RuntimeClass whose name is empty,
+// which the API server rejects.
+func runtimeClassName(inst *hermesv1.HermesInstance) *string {
+	if inst.Spec.Scheduling.RuntimeClassName == "" {
+		return nil
+	}
+	return Ptr(inst.Spec.Scheduling.RuntimeClassName)
 }
 
 func imageRef(inst *hermesv1.HermesInstance) string {

--- a/internal/resources/statefulset_test.go
+++ b/internal/resources/statefulset_test.go
@@ -196,6 +196,30 @@ func TestBuildStatefulSet_Scheduling(t *testing.T) {
 	assert.NotNil(t, podSpec.Affinity)
 }
 
+func TestBuildStatefulSet_RuntimeClassName(t *testing.T) {
+	t.Parallel()
+	inst := minimalInstance()
+	inst.Spec.Scheduling.RuntimeClassName = "gvisor"
+
+	podSpec := BuildStatefulSet(inst, nil).Spec.Template.Spec
+
+	if assert.NotNil(t, podSpec.RuntimeClassName) {
+		assert.Equal(t, "gvisor", *podSpec.RuntimeClassName)
+	}
+}
+
+// Unset must render nil, not a pointer to "". An empty RuntimeClassName is not
+// "cluster default" — it names a RuntimeClass with an empty name, which the API
+// server rejects.
+func TestBuildStatefulSet_RuntimeClassNameUnsetIsNil(t *testing.T) {
+	t.Parallel()
+	inst := minimalInstance()
+
+	podSpec := BuildStatefulSet(inst, nil).Spec.Template.Spec
+
+	assert.Nil(t, podSpec.RuntimeClassName)
+}
+
 func TestBuildStatefulSet_TopologySpread(t *testing.T) {
 	t.Parallel()
 	inst := minimalInstance()


### PR DESCRIPTION
Implements #115 (the minimal ask: a single `runtimeClassName` field rather than a general pod-template override).

## What

```yaml
spec:
  scheduling:
    runtimeClassName: gvisor
```

Passed straight through to the instance pod template, so the agent can be placed on a sandboxed runtime (gVisor `runsc`, Kata) on dedicated capacity.

## Two details worth calling out

**Unset must be `nil`, not `&""`.** An empty `RuntimeClassName` does not mean "cluster default" — it names a RuntimeClass whose name is empty, which the API server rejects. `runtimeClassName()` maps `""` to `nil`, and `TestBuildStatefulSet_RuntimeClassNameUnsetIsNil` pins that, since it's the kind of thing a later refactor silently breaks.

**Validated as a DNS subdomain** (`MaxLength=253` + the standard pattern). A malformed name is rejected at admission instead of leaving the pod permanently unschedulable with no obvious cause.

The operator deliberately does not create or verify the RuntimeClass — those are cluster-scoped infrastructure owned by the cluster admin. As the issue notes, an unknown name leaves the pod unschedulable; that's the expected failure mode.

## Chose the narrow field over `podOverrides`

The issue offered either. A general pod-template escape hatch would also cover this, but it's a much wider contract to support and makes the operator's rendered pod non-deterministic. Going with the minimal field; if a broader override is wanted later it can subsume this.

## Verification

`make manifests generate sync-chart-crds sync-bundle-crds api-docs` — CRD, chart CRD, OLM bundle and generated API reference all regenerated and committed. `make test` green, `make lint` 0 issues.

`test/conformance` fails locally, but identically on a clean `main` checkout — it needs a live cluster and is the known pre-existing gap, unrelated to this change.

@ilazaridis you offered to test a build — this branch builds an image on CI, happy to point you at a tag once it lands if that's useful.