### PR TITLE
fix(chart): stop rendering a doubled v in the operator image tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,9 +164,13 @@ jobs:
         run: |
           CHART_VERSION="${{ github.ref_name }}"
           CHART_VERSION="${CHART_VERSION#v}"
+          # appVersion must be the bare version, matching what release-please
+          # writes into Chart.yaml. The chart templates re-add the "v" to reach
+          # the published image tag; passing the v-prefixed ref here produced
+          # "vv<version>" (see #113).
           helm package charts/hermes-operator \
             --version "${CHART_VERSION}" \
-            --app-version "${{ github.ref_name }}"
+            --app-version "${CHART_VERSION}"
           PUSH_OUT=$(helm push "hermes-operator-${CHART_VERSION}.tgz" oci://ghcr.io/paperclipinc/charts 2>&1)
           echo "${PUSH_OUT}"
           DIGEST=$(echo "${PUSH_OUT}" | awk '/Digest:/ {print $2}')

--- a/charts/hermes-operator/templates/_helpers.tpl
+++ b/charts/hermes-operator/templates/_helpers.tpl
@@ -13,6 +13,12 @@ app.kubernetes.io/name: {{ include "hermes-operator.fullname" . }}
 {{- end -}}
 
 {{- define "hermes-operator.image" -}}
-{{- $tag := default (printf "v%s" .Chart.AppVersion) .Values.image.tag -}}
+{{- /*
+Fall back to the chart's appVersion, normalised to the v-prefixed form the
+release workflow publishes. appVersion is written bare by release-please in
+Chart.yaml but a packaged chart may carry it v-prefixed, so strip any existing
+"v" before adding one - otherwise the tag renders as "vv0.1.19".
+*/ -}}
+{{- $tag := default (printf "v%s" (trimPrefix "v" .Chart.AppVersion)) .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end -}}

--- a/hack/check-chart-image-tags.sh
+++ b/hack/check-chart-image-tags.sh
@@ -2,16 +2,33 @@
 # Assert that every image reference the chart renders at its own defaults is
 # actually pullable from the registry.
 #
-# Regression guard for #113: release-please used to write a bare version into
-# values.yaml `image.tag` while the release workflow only publishes v-prefixed
-# tags, so `helm install` at the chart's own defaults produced ImagePullBackOff.
+# Regression guard for #113, which had two distinct failure modes:
+#
+#   1. release-please wrote a bare version into values.yaml `image.tag` while
+#      the release workflow only publishes v-prefixed tags, so a default
+#      install rendered ghcr.io/...:0.1.18 and hit ImagePullBackOff.
+#   2. After (1) was fixed by falling back to the chart's appVersion, the
+#      release job packaged the chart with a v-prefixed --app-version while the
+#      template added its own "v" — shipping ghcr.io/...:vv0.1.19.
+#
+# (2) is why this script checks the *packaged* chart as well as the working
+# tree: they can render different tags, and only the packaged one is published.
 #
 # Uses the anonymous registry token + manifest HEAD, so it needs no credentials
 # for public images.
 set -euo pipefail
 
 CHART_DIR="${CHART_DIR:-charts/hermes-operator}"
-APP_VERSION="$(sed -nE 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?/\1/p' "${CHART_DIR}/Chart.yaml")"
+CHART_NAME="$(basename "${CHART_DIR}")"
+OPERATOR_REPO="paperclipinc/hermes-operator"
+
+# Bare version, however Chart.yaml happens to spell it.
+APP_VERSION="$(sed -nE 's/^appVersion:[[:space:]]*"?v?([^"[:space:]]+)"?/\1/p' "${CHART_DIR}/Chart.yaml")"
+
+if [[ -z "$APP_VERSION" ]]; then
+  echo "ERROR: could not read appVersion from ${CHART_DIR}/Chart.yaml" >&2
+  exit 1
+fi
 
 fail=0
 
@@ -30,23 +47,28 @@ check_ref() {
     return 0
   fi
 
-  # The operator image is only ever published v-prefixed. A bare semver here is
-  # the #113 regression: it renders an unpullable reference. Catch it by shape,
-  # so it fails even before the tag would have had a chance to exist.
-  if [[ "$repo" == "paperclipinc/hermes-operator" && "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "  FAIL $ref (bare version tag; the release workflow publishes v${tag})"
-    fail=1
-    return 0
-  fi
-
-  # The operator image is published by the release workflow, which runs *after*
-  # release-please bumps appVersion. On a release PR (and on main until the
-  # release job finishes) the chart legitimately renders a tag that does not
-  # exist yet. Exempt exactly that case from the existence check, but still
-  # enforce the v-prefix format that #113 was about.
-  if [[ "$repo" == "paperclipinc/hermes-operator" && "$tag" == "v${APP_VERSION}" ]]; then
+  # Shape check first, and strictly. The operator image is published as exactly
+  # v<semver>. Anything else is a rendering bug, and checking the shape rather
+  # than only registry existence means it fails even for a version that has not
+  # been published yet — which is when these bugs are actually introduced.
+  # Catches both the bare "0.1.18" and the doubled "vv0.1.19".
+  if [[ "$repo" == "$OPERATOR_REPO" ]]; then
+    if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+      echo "  FAIL $ref (tag must be exactly v<semver>; got '${tag}')"
+      fail=1
+      return 0
+    fi
+    if [[ "$tag" != "v${APP_VERSION}" ]]; then
+      echo "  FAIL $ref (tag '${tag}' does not match appVersion v${APP_VERSION})"
+      fail=1
+      return 0
+    fi
+    # The release job publishes the image *after* this runs on the release
+    # commit, so the pending version legitimately does not exist yet. The shape
+    # and appVersion checks above already passed, which is the part that
+    # actually regresses.
     if ! git rev-parse -q --verify "refs/tags/v${APP_VERSION}" >/dev/null 2>&1; then
-      echo "  SKIP $ref (v${APP_VERSION} is the pending release; format is correct)"
+      echo "  SKIP $ref (v${APP_VERSION} is the pending release; shape verified)"
       return 0
     fi
   fi
@@ -70,28 +92,52 @@ check_ref() {
   fi
 }
 
-echo "Rendering ${CHART_DIR} at its defaults..."
-refs=$(helm template hermes-operator "${CHART_DIR}" \
-  | grep -oE 'image: "?[a-z0-9./-]+:[A-Za-z0-9._-]+"?' \
-  | sed -E 's/^image: "?//; s/"?$//' \
-  | sort -u)
+render_refs() {
+  helm template hermes-operator "$1" \
+    | grep -oE 'image: "?[a-z0-9./-]+:[A-Za-z0-9._-]+"?' \
+    | sed -E 's/^image: "?//; s/"?$//' \
+    | sort -u
+}
 
-if [[ -z "$refs" ]]; then
-  echo "ERROR: no image references found in rendered chart — check the grep." >&2
-  exit 1
-fi
+check_all() {
+  local label="$1" chart="$2" refs
+  refs="$(render_refs "$chart")"
+  if [[ -z "$refs" ]]; then
+    echo "ERROR: no image references found in ${label} — check the grep." >&2
+    exit 1
+  fi
+  echo "Checking ${label}:"
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] && check_ref "$ref"
+  done <<<"$refs"
+}
 
-echo "Checking rendered image references:"
-while IFS= read -r ref; do
-  [[ -n "$ref" ]] && check_ref "$ref"
-done <<<"$refs"
+check_all "working-tree chart" "${CHART_DIR}"
+
+# The release job repackages with --version/--app-version derived from the git
+# tag, so the packaged chart can render a different tag than the working tree.
+# Check both spellings of appVersion, since only the packaged form is published.
+echo
+for av in "${APP_VERSION}" "v${APP_VERSION}"; do
+  pkgdir="$(mktemp -d)"
+  helm package "${CHART_DIR}" --version "${APP_VERSION}" --app-version "${av}" -d "$pkgdir" >/dev/null
+  pkg="${pkgdir}/${CHART_NAME}-${APP_VERSION}.tgz"
+  if [[ ! -f "$pkg" ]]; then
+    echo "ERROR: expected packaged chart at $pkg" >&2
+    rm -rf "$pkgdir"
+    exit 1
+  fi
+  check_all "packaged chart (--app-version ${av})" "$pkg"
+  rm -rf "$pkgdir"
+done
 
 if [[ "$fail" -ne 0 ]]; then
   echo
-  echo "One or more chart default image tags are unpullable." >&2
-  echo "The release workflow publishes v-prefixed tags (v<version>), so the" >&2
-  echo "chart must render those — see hack/check-chart-image-tags.sh header." >&2
+  echo "One or more chart default image tags are wrong." >&2
+  echo "The release workflow publishes exactly v<version>, so the chart must" >&2
+  echo "render that — in the working tree AND when packaged. See the header." >&2
   exit 1
 fi
 
+echo
 echo "All chart default image tags resolve."


### PR DESCRIPTION
**Chart 0.1.19 is broken — this is the follow-up fix.** Verified against the published artifact:

```
$ helm pull oci://ghcr.io/paperclipinc/charts/hermes-operator --version 0.1.19
$ helm template hermes-operator hermes-operator-0.1.19.tgz | grep image:
    image: "ghcr.io/paperclipinc/hermes-operator:vv0.1.19"
```

So #122 traded #113's bare `0.1.18` for `vv0.1.19`. Both unpullable. My mistake — flagging it plainly.

## Cause

`release.yaml` packages with `--app-version "\${{ github.ref_name }}"` (= `v0.1.19`) while `--version` strips the prefix. `_helpers.tpl` then did `printf "v%s" .Chart.AppVersion`, adding a second `v`.

This predates #113's fix, but was masked: `values.yaml` `image.tag` was populated, so the appVersion fallback never ran. Emptying the tag activated the fallback and exposed the latent bug.

## Fix

Both sides, so neither alone is load-bearing:

- `release.yaml` passes the bare `\${CHART_VERSION}`, matching what release-please writes into `Chart.yaml`.
- `_helpers.tpl` trims a leading `v` before adding one, so the template is correct for either spelling.

## Why the guard missed it

`hack/check-chart-image-tags.sh` only rendered the working tree, where `Chart.yaml`'s appVersion is bare — so it rendered `v0.1.19` and passed, while the *packaged* chart rendered `vv0.1.19`. Only the packaged form is ever published.

It now:
1. renders the packaged chart too, with appVersion in **both** spellings;
2. validates the operator tag against `^v<semver>$` instead of only checking registry existence, so a malformed tag fails on shape before it could ever have been published.

| scenario | exit |
|---|---|
| fixed chart (working tree + both packaged forms) | `0` |
| doubled-v regression (what shipped in 0.1.19) | `1` — `tag must be exactly v<semver>; got 'vv0.1.19'` |
| original bare-tag regression (#113) | `1` |

Once this lands I'll cut 0.1.20 and verify the published chart end-to-end by pulling it, rather than trusting the source render as I did last time.