### PR TITLE
fix(runtime): keep user config writable

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -34,7 +34,11 @@ the PVC) is **gone**. Only mutable state lives on the volume.
 
 Persistent state lives at **`/opt/data`**, the PVC mount, and `HERMES_HOME` is
 set to `/opt/data`. (The previous runtime used `/home/hermes/.hermes`.) The
-rendered `config.yaml` is mounted read-only at `/opt/data/config.yaml`.
+operator-rendered `config.yaml` is mounted read-only at
+`/etc/hermes/config.yaml`, Hermes' managed-scope location. The user/runtime
+configuration remains writable and persistent at `/opt/data/config.yaml` so
+commands such as `/sethome` can save state. Hermes merges the managed scope over
+the runtime file per leaf, so declarative operator values remain authoritative.
 
 ## Security posture and the SCC tradeoff
 

--- a/hack/dev/hermes-upstream-validate.yaml
+++ b/hack/dev/hermes-upstream-validate.yaml
@@ -103,7 +103,7 @@ spec:
             - name: data
               mountPath: /opt/data
             - name: config
-              mountPath: /opt/data/config.yaml
+              mountPath: /etc/hermes/config.yaml
               subPath: config.yaml
               readOnly: true
       volumes:

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -79,8 +79,12 @@ func BuildStatefulSet(inst *hermesv1.HermesInstance, extraInits []corev1.Contain
 			// HERMES_HOME on the upstream image is /opt/data (the persistent volume).
 			{Name: "data", MountPath: "/opt/data"},
 			{
-				Name:      "config",
-				MountPath: "/opt/data/config.yaml",
+				Name: "config",
+				// Mount the operator-rendered config as Hermes' immutable managed scope.
+				// The writable user config remains on the data PVC at
+				// /opt/data/config.yaml so runtime commands such as /sethome can persist
+				// user-owned state without replacing the managed configuration.
+				MountPath: "/etc/hermes/config.yaml",
 				SubPath:   "config.yaml",
 				ReadOnly:  true,
 			},

--- a/internal/resources/statefulset_test.go
+++ b/internal/resources/statefulset_test.go
@@ -109,13 +109,17 @@ func TestBuildStatefulSet_VolumesAndMounts(t *testing.T) {
 	sts := BuildStatefulSet(minimalInstance(), nil)
 	c := sts.Spec.Template.Spec.Containers[0]
 
-	mountNames := map[string]string{}
+	mountsByName := map[string]corev1.VolumeMount{}
 	for _, m := range c.VolumeMounts {
-		mountNames[m.Name] = m.MountPath
+		mountsByName[m.Name] = m
+		assert.NotEqual(t, "/opt/data/config.yaml", m.MountPath,
+			"runtime config must remain writable on the data PVC")
 	}
-	assert.Equal(t, "/opt/data", mountNames["data"], "PVC mounted at HERMES_HOME (/opt/data)")
-	assert.Equal(t, "/opt/data/config.yaml", mountNames["config"], "configmap subPath at config.yaml")
-	assert.Equal(t, "/tmp", mountNames["tmp"], "writable /tmp")
+	assert.Equal(t, "/opt/data", mountsByName["data"].MountPath, "PVC mounted at HERMES_HOME (/opt/data)")
+	assert.Equal(t, "/etc/hermes/config.yaml", mountsByName["config"].MountPath,
+		"operator config is mounted as Hermes managed scope")
+	assert.True(t, mountsByName["config"].ReadOnly, "managed config must be immutable")
+	assert.Equal(t, "/tmp", mountsByName["tmp"].MountPath, "writable /tmp")
 }
 
 func minimalInstance() *hermesv1.HermesInstance {


### PR DESCRIPTION
## Summary
- mount operator-rendered config at Hermes managed scope (`/etc/hermes/config.yaml`)
- leave `/opt/data/config.yaml` writable for runtime mutations such as `/sethome`
- document managed-over-user config layering

## Root cause
The operator mounted its ConfigMap directly over `$HERMES_HOME/config.yaml` read-only. `/sethome` calls `save_config()`, whose atomic replace then failed with `EROFS`.

## Tests
- RED: updated volume-mount test failed against `/opt/data/config.yaml`
- GREEN: `go test ./internal/resources -count=1`
- Integration: current Hermes image loaded managed config from `/etc/hermes`, persisted a WhatsApp home channel to `/opt/data/config.yaml`, stripped managed keys from the user file, and reloaded the merged effective config successfully.

Full `go test ./...` reaches the controller/e2e suites but those require envtest binaries and a Kubernetes/Helm environment not present in the plain Go container.