### PR TITLE
docs(upgrade): add upgrade notes, starting with the agent resource floor

### DIFF
--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Self-Configuration: selfconfig.md
       - Platform Gateways Runbook: runbook-platform-gateways.md
   - Migration and Compatibility:
+      - Upgrade Notes: upgrade-notes.md
       - Migration: migration.md
       - API Versioning: api-versioning.md
       - Supported Versions: supported-versions.md

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,6 +103,8 @@ It exists because an agent container executing model-driven code should not run 
 
 Set `applyOperatorDefaults: false` to keep the unset side genuinely unbounded, for instance where a known working set exceeds the limits above. Namespace-level `LimitRange` defaults only apply to a side left unbounded that way.
 
+This floor arrived in 0.2.0 and changes the rendered pod for instances that previously left `spec.resources` unset. See [Upgrade Notes](upgrade-notes.md#020).
+
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `spec.resources.requests` | `corev1.ResourceList` | operator floor above | Resource requests map (e.g. `cpu: 100m`, `memory: 128Mi`). |

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -1,0 +1,88 @@
+# Upgrade Notes
+
+Per-release notes for changes that alter the behaviour of **existing**
+instances, as opposed to adding opt-in surface. Read the entry for every
+version you are skipping over, not just the one you are moving to.
+
+Entries are newest first. Versions not listed here need no action beyond the
+normal `helm upgrade` or OLM subscription bump.
+
+## 0.2.0
+
+### The agent container now has default resource requests and limits
+
+**What changed.** A `HermesInstance` that left `spec.resources` unset used to
+render `resources: {}`, so the agent container ran unbounded in the BestEffort
+QoS class. The operator now supplies a floor:
+
+```yaml
+requests:
+  cpu: 500m
+  memory: 512Mi
+limits:
+  cpu: "2"
+  memory: 4Gi
+```
+
+Requests and limits resolve independently, so an instance that set only one
+side keeps it verbatim and picks up the default for the other. A block you set
+is used as written, never key-merged.
+
+**Why.** The agent executes model-driven code. Unbounded, a single runaway
+instance can starve every other pod on its node, and a BestEffort pod is the
+first thing the kubelet evicts under memory pressure.
+
+**Who is affected.** Any instance that left `spec.resources` (or the side in
+question) unset. After the upgrade its pods are recreated with the values
+above. Two ways that bites:
+
+- An instance whose working set exceeds **4Gi** of memory is now OOM-killed
+  where it previously grew freely. The browser stack in the agent image
+  (Playwright/Chromium) is the usual reason a real workload gets near this.
+- An instance that burst past **2 CPUs** is now throttled.
+- On a tight cluster, the new 500m/512Mi requests can leave pods `Pending`
+  that previously scheduled anywhere, because BestEffort pods request nothing.
+
+If you rely on a namespace `LimitRange` to supply these values, note that the
+operator now wins over the LimitRange default.
+
+**What to do before upgrading.** Check what your instances actually use:
+
+```bash
+kubectl top pod -l app.kubernetes.io/name=hermes-agent --all-namespaces
+```
+
+For anything close to or above the floor, pick one of:
+
+```yaml
+# Set the values you want. An explicit block always wins.
+spec:
+  resources:
+    limits:
+      cpu: "4"
+      memory: 16Gi
+```
+
+```yaml
+# Or keep the unset side genuinely unbounded, as before.
+spec:
+  resources:
+    applyOperatorDefaults: false
+```
+
+`applyOperatorDefaults` also exists on `HermesClusterDefaults.spec.resources`,
+so the opt-out can be applied cluster-wide for the duration of a migration:
+
+```yaml
+apiVersion: hermes.agent/v1
+kind: HermesClusterDefaults
+metadata:
+  name: cluster
+spec:
+  resources:
+    applyOperatorDefaults: false
+```
+
+Instances that set the flag themselves still win over the cluster default.
+
+See `spec.resources` in [the API reference](api-reference.md#specresources).


### PR DESCRIPTION
Follow-up to #151 (#124).

## Why

#151 changes the rendered pod for every instance that left `spec.resources` unset, and the repo had nowhere to say so. #124 explicitly asked for a release note.

Worse, the note that was supposed to carry it got dropped. This repo has `squash_merge_commit_message=PR_BODY`, so a squash merge uses the **PR description** as the commit body, not the commit message. #151's `BREAKING CHANGE:` footer lived in the commit message, so it never reached release-please: 35100b1 on `main` carries the PR body, and release PR #152 is still cutting **0.1.21**, a patch, for a change that can OOM-kill a running instance.

## What this does

1. Adds `docs/upgrade-notes.md`, the per-release home for changes that alter the behaviour of existing instances (as opposed to adding opt-in surface), linked from the docs-site nav under Migration and Compatibility and from `spec.resources` in the API reference.
2. The 0.2.0 entry covers what changed, why, who is affected (working sets above 4Gi, bursts past 2 CPUs, and BestEffort pods that now carry requests on a tight cluster), how to check with `kubectl top` before upgrading, and both escape hatches: an explicit `spec.resources` block, or `applyOperatorDefaults: false` per instance or cluster-wide via `HermesClusterDefaults`.
3. Restores the `BREAKING CHANGE:` footer, so release-please cuts a minor (`bump-minor-pre-major` on 0.x) and the changelog carries the warning under its own heading.

## Merging this one

**Merge with an explicit squash body, not the default.** Because of the `PR_BODY` setting above, `gh pr merge --squash` alone would drop the footer again and this PR would fail at its own job. Use:

```
gh pr merge <n> --squash --body "$(git log -1 --format=%b <commit>)"
```

Worth considering separately: flipping `squash_merge_commit_message` to `COMMIT_MESSAGES` repo-wide, so conventional-commit footers survive by default. That is a repo setting change, so leaving it as a recommendation rather than doing it here.

## Verification

`make docs-build` (mkdocs `--strict`) passes; the new page and its nav entry render, and the `#020` anchor from the API reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t3bi2beVNVVHAxK36dmXm